### PR TITLE
Add YDB instrumentation tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,13 @@ import shutil
 from collections.abc import Iterator
 
 import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from tests.ydb_container import YDBContainer
+from ydb_instrumentor import YDBInstrumentor
 
 
 @pytest.fixture(scope="session")
@@ -16,3 +21,22 @@ def ydb_container() -> Iterator[YDBContainer]:
         yield container
     finally:
         container.stop()
+
+
+@pytest.fixture
+def instrument_ydb() -> Iterator[InMemorySpanExporter]:
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    previous_provider = trace.get_tracer_provider()
+    trace.set_tracer_provider(provider)
+
+    instrumentor = YDBInstrumentor(True, True)
+    instrumentor.instrument()
+    try:
+        yield exporter
+    finally:
+        instrumentor.uninstrument()
+        trace.set_tracer_provider(previous_provider)
+        exporter.clear()

--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -1,0 +1,51 @@
+import pytest
+import ydb
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from tests.ydb_container import YDBContainer
+
+
+@pytest.mark.asyncio
+async def test_query_session_is_traced(ydb_container: YDBContainer, instrument_ydb: InMemorySpanExporter) -> None:
+    connection_string = ydb_container.get_connection_string()
+    async with (
+        ydb.aio.Driver(connection_string=connection_string) as driver,
+        ydb.aio.QuerySessionPool(driver, size=1) as pool,
+        pool.checkout() as session,
+    ):
+        await driver.wait()
+        cursor = await session.execute("SELECT 1 + 1")
+        _ = [row async for rs in cursor for row in rs.rows]
+
+    spans = instrument_ydb.get_finished_spans()
+    assert len(spans) == 1  # noqa: S101
+    span = spans[0]
+    assert span.name == "YdbQuery"  # noqa: S101
+    assert span.attributes["ydb.query.text"] == "SELECT 1 + 1"  # noqa: S101
+    assert "ydb.session.id" in span.attributes  # noqa: S101
+    assert "ydb.query.stats.total_duration" in span.attributes  # noqa: S101
+    instrument_ydb.clear()
+
+
+@pytest.mark.asyncio
+async def test_query_tx_is_traced(ydb_container: YDBContainer, instrument_ydb: InMemorySpanExporter) -> None:
+    connection_string = ydb_container.get_connection_string()
+    async with (
+        ydb.aio.Driver(connection_string=connection_string) as driver,
+        ydb.aio.QuerySessionPool(driver, size=1) as pool,
+        pool.checkout() as session,
+        session.transaction() as tx,
+    ):
+        await driver.wait()
+        cursor = await tx.execute("SELECT 1 + 1")
+        _ = [row async for rs in cursor for row in rs.rows]
+        await tx.commit()
+
+    spans = instrument_ydb.get_finished_spans()
+    assert len(spans) == 1  # noqa: S101
+    span = spans[0]
+    assert span.attributes["ydb.query.text"] == "SELECT 1 + 1"  # noqa: S101
+    assert "ydb.session.id" in span.attributes  # noqa: S101
+    assert "ydb.tx.id" in span.attributes  # noqa: S101
+    assert "ydb.tx.mode" in span.attributes  # noqa: S101
+    instrument_ydb.clear()

--- a/ydb_instrumentor/__init__.py
+++ b/ydb_instrumentor/__init__.py
@@ -1,1 +1,3 @@
 from .ydb_instrumentor import YDBInstrumentor
+
+__all__ = ["YDBInstrumentor"]


### PR DESCRIPTION
## Summary
- add fixture enabling `YDBInstrumentor`
- test tracing for query session and query transaction
- export `YDBInstrumentor` via `__all__`

## Testing
- `ruff check .`
- `pytest -q` *(tests skipped due to missing Docker)*

------
https://chatgpt.com/codex/tasks/task_e_6857e9fd120c8328b85cd9becaad53bc